### PR TITLE
updated stated default value of MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ action.
 | `type`            | what is the artifact type                                             | `string`  |
 | `classification`  | for file and archives, what is the class of artifact (optional)       | `string`  |
 | `mode`            | determine if we should run in debug or standard info mode (optional)  | `string`  |
-| `dryrun`          | determine if we should run in dryrun mode or note (optional)          | `string`  |
 
 ### Default Values
 
@@ -44,7 +43,6 @@ action.
 | `type`            | **NONE**  | "FILE", "ARCHIVE", "IMAGE", "FIRMWARE"                    |
 | `classification`  | **NONE**  | "RFSIMAGE", "YOCTO"                                       |
 | `mode`            | `"INFO"`  | "DEBUG", "INFO"                                           |
-| `dryrun`          | `false`   | "TRUE", "FALSE"                                           |
 
 ## Development
 
@@ -74,5 +72,4 @@ For example, see the following:
           path: "**/release.img"
           classification: "RFSIMAGE"
           mode: "INFO"
-          dryrun: "false"
 ```


### PR DESCRIPTION
I spotted a discrepancy or two in the README docs while updating the official Chassy documentation's reference to our GitHub actions. I'm accounting for those corrections in this PR.